### PR TITLE
Multiple definitions for max speed

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -54,6 +54,7 @@ public final class Constants {
     }
 
     public static final class NEOVortexConstants {
+      public static final AngularVelocity kFreeSpeed = RPM.of(6784);
       public static final int kDefaultCurrentLimit = 60;
     }
   }

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -199,7 +199,7 @@ public class Drive extends SubsystemBase {
     // Calculate module setpoints
     ChassisSpeeds discreteSpeeds = ChassisSpeeds.discretize(speeds, 0.02);
     SwerveModuleState[] setpointStates = kinematics.toSwerveModuleStates(discreteSpeeds);
-    SwerveDriveKinematics.desaturateWheelSpeeds(setpointStates, maxSpeed.in(MetersPerSecond));
+    SwerveDriveKinematics.desaturateWheelSpeeds(setpointStates, maxWheelSpeed.in(MetersPerSecond));
 
     // Log unoptimized setpoints
     Logger.recordOutput("SwerveStates/Setpoints", setpointStates);
@@ -337,11 +337,11 @@ public class Drive extends SubsystemBase {
 
   /** Returns the maximum linear speed in meters per sec. */
   public double getMaxLinearSpeedMetersPerSec() {
-    return maxSpeed.in(MetersPerSecond);
+    return maxChassisSpeed.in(MetersPerSecond);
   }
 
   /** Returns the maximum angular speed in radians per sec. */
   public double getMaxAngularSpeedRadPerSec() {
-    return maxSpeed.in(MetersPerSecond) / driveBaseRadius.in(Meters);
+    return maxChassisSpeed.in(MetersPerSecond) / driveBaseRadius.in(Meters);
   }
 }

--- a/src/main/java/frc/robot/subsystems/drive/DriveConstants.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveConstants.java
@@ -28,8 +28,7 @@ import edu.wpi.first.units.measure.MomentOfInertia;
 import frc.robot.Constants.MotorConstants.NEOVortexConstants;
 
 public class DriveConstants {
-  public static final LinearVelocity maxSpeed =
-      MetersPerSecond.of(1.1); // Commented out on reefscape bot
+  public static final LinearVelocity maxChassisSpeed = MetersPerSecond.of(1.1);
   public static final double odometryFrequency = 100.0; // Hz
   private static final double wheelBase = Units.inchesToMeters(27);
   private static final double trackWidth = Units.inchesToMeters(21);
@@ -75,6 +74,12 @@ public class DriveConstants {
   // Drive encoder configuration
   public static final double driveEncoderPositionFactor =
       2 * Math.PI / driveMotorReduction; // Rotor Rotations -> Wheel Radians
+  public static final LinearVelocity maxWheelSpeed =
+      MetersPerSecond.of(
+          0.9
+              * wheelRadius.in(Meters)
+              * NEOVortexConstants.kFreeSpeed.in(RotationsPerSecond)
+              * driveMotorReduction);
   public static final double driveEncoderVelocityFactor =
       (2 * Math.PI) / 60.0 / driveMotorReduction; // Rotor RPM -> Wheel Rad/Sec
 
@@ -120,7 +125,7 @@ public class DriveConstants {
           robotMOI.in(KilogramSquareMeters),
           new ModuleConfig(
               wheelRadius.in(Meters),
-              maxSpeed.in(MetersPerSecond),
+              maxChassisSpeed.in(MetersPerSecond),
               wheelCOF,
               driveGearbox.withReduction(driveMotorReduction),
               NEOVortexConstants.kDefaultCurrentLimit,


### PR DESCRIPTION
The speed of teleop driving should be proportional to the driver's joystick input and cap out at a maximum that is set by the driver. This is intended to be a user-adjustable value.

Only desaturate swerve wheel speeds if the fastest drive motor is at very close to free speed, which is a known value from the motor spec sheet. Unnecessary desaturation will force the robot to deviate from the planned trajectory, especially when the trajectory is optimized for speed.